### PR TITLE
fix: take into account DPI when calculating mouse pos

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -115,9 +115,13 @@ impl UI {
     }
 
     fn show_window(&mut self, ctx: &egui::Context) {
-        // get current mouse position
+        let scale_factor = ctx.pixels_per_point();
         let (mouse_x, mouse_y) = match Mouse::get_mouse_position() {
-            Mouse::Position { x, y } => (x as f32, y as f32),
+            Mouse::Position { x, y } => {
+                let scaled_x = (x as f32) / scale_factor;
+                let scaled_y = (y as f32) / scale_factor;
+                (scaled_x, scaled_y)
+            }
             _ => (0.0, 0.0),
         };
 


### PR DESCRIPTION
ref: https://github.com/fayez-nazzal/mouse_position/issues/2

correctly show at cursor pos now

<img width="1283" height="645" alt="image" src="https://github.com/user-attachments/assets/5c087ade-3c5f-4313-a680-91e7d76b624b" />
